### PR TITLE
Fix coordinate order in line_geometries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Changelog of threedigrid-builder
 
 - Added invert_level_start_point and invert_level_end_point attributes to lines.
 
+- Fixed coordinate order in lines.line_geometries field in gridadmin.h5.
+
 
 0.3.0 (2021-07-28)
 ------------------

--- a/threedigrid_builder/interface/gridadmin.py
+++ b/threedigrid_builder/interface/gridadmin.py
@@ -364,12 +364,10 @@ class GridAdminOut(OutputInterface):
             lines.discharge_coefficient_positive,
         )
 
-        # Transform an array of linestrings to list of coordinate arrays (x,y,x,y,...)
-        coords = pygeos.get_coordinates(lines.line_geometries)
-        end = np.cumsum(pygeos.get_num_coordinates(lines.line_geometries))
-        start = np.roll(end, 1)
-        start[0] = 0
-        line_geometries = [coords[a:b].ravel() for a, b in zip(start, end)]
+        # Transform an array of linestrings to list of coordinate arrays (x,x,y,y)
+        line_geometries = [
+            pygeos.get_coordinates(x).T.ravel() for x in lines.line_geometries
+        ]
         line_geometries.insert(0, np.array([-9999.0, -9999.0]))
         # The dataset has a special "variable length" dtype. This one is special write method.
         vlen_dtype = h5py.special_dtype(vlen=np.dtype(float))

--- a/threedigrid_builder/tests/test_gridadmin.py
+++ b/threedigrid_builder/tests/test_gridadmin.py
@@ -227,6 +227,14 @@ def test_write_lines(h5_out, dataset, shape, dtype):
     assert h5_out["lines"][dataset].dtype == np.dtype(dtype)
 
 
+def test_line_geometries(h5_out):
+    # line geometries are stored as a variable-length array [x, x, ..., y, y, ...]
+    data = h5_out["lines"]["line_geometries"][:]
+    assert data[0].tolist() == [-9999, -9999]
+    assert data[1].tolist() == [1, 2, 1, 2]
+    assert data[2].tolist() == [1, 2, 3, 1, 2, 3]
+
+
 @pytest.mark.parametrize(
     "dataset,shape,dtype",
     [


### PR DESCRIPTION
The order should be (x, x, y, y,) instead of (x,y,x,y)