### PR TITLE
Added has_initial_waterlevels and removed global

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog of threedigrid-builder
 
 - Handle user-supplied 1D-2D lines (connected point / calculation point).
 
-- Write initial_waterlevel for connection nodes.
+- Write initial_waterlevel for 1D nodes and add 'has_initial_waterlevels' to meta.
 
 
 0.4.0 (2021-09-23)

--- a/threedigrid_builder/application.py
+++ b/threedigrid_builder/application.py
@@ -153,7 +153,6 @@ def _make_gridadmin(
             channels=channels,
             pipes=pipes,
             culverts=culverts,
-            global_initial_waterlevel=grid_settings.initial_waterlevel,
         )
         grid.set_boundary_conditions_1d(db.get_boundary_conditions_1d())
         grid.set_cross_sections(definitions)

--- a/threedigrid_builder/base/settings.py
+++ b/threedigrid_builder/base/settings.py
@@ -18,7 +18,6 @@ class GridSettings:
     grid_space: float
     dist_calc_points: float
     kmax: int
-    initial_waterlevel: float
     embedded_cutoff_threshold: float = 0.05
     max_angle_1d_advection: float = 90.0
 

--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -99,6 +99,7 @@ class GridMeta:
     has_pumpstations: bool = False
     has_simple_infiltration: bool = False
     has_interflow: bool = False
+    has_initial_waterlevels: bool = True
 
     extent_1d: Optional[Tuple[float, float, float, float]] = None
     extent_2d: Optional[Tuple[float, float, float, float]] = None
@@ -450,9 +451,7 @@ class Grid:
         # Fix channel lines: set dpumax of channel lines that have no interpolated nodes
         csl_module.fix_dpumax(self.lines, self.nodes)
 
-    def set_initial_waterlevels(
-        self, connection_nodes, channels, pipes, culverts, global_initial_waterlevel
-    ):
+    def set_initial_waterlevels( self, connection_nodes, channels, pipes, culverts):
         """Apply initial waterlevels (global or per connection nodes) to all 1D nodes.
 
         Bottom levels (dmax) should be set already.
@@ -462,7 +461,6 @@ class Grid:
             channels (Channels)
             pipes (Pipes)
             culverts (Culverts)
-            global_initial_waterlevel (float): a global value for initial_waterlevel
 
         """
         initial_waterlevels_module.compute_initial_waterlevels(
@@ -471,7 +469,6 @@ class Grid:
             channels=channels,
             pipes=pipes,
             culverts=culverts,
-            global_initial_waterlevel=global_initial_waterlevel,
         )
 
     def set_obstacles(self, obstacles):
@@ -616,6 +613,7 @@ class Grid:
         self.lines.set_discharge_coefficients()
         if len(self.pumps) > 0:
             self.meta.has_pumpstations = True
+        self.meta.has_initial_waterlevels = np.isfinite(self.nodes.initial_waterlevel).any()
         self.meta.extent_1d = self.nodes.get_extent_1d()
         self.meta.extent_2d = self.nodes.get_extent_2d()
         self.meta.has_1d = self.meta.extent_1d is not None

--- a/threedigrid_builder/tests/test_db.py
+++ b/threedigrid_builder/tests/test_db.py
@@ -202,7 +202,6 @@ def test_get_settings(db):
     assert g.kmax == 4
     assert g.embedded_cutoff_threshold == 0.05
     assert g.max_angle_1d_advection == 90.0
-    assert g.initial_waterlevel == -9999.0
     # use_2d is based on the presence of dem_file:
     assert g.use_2d is True
 

--- a/threedigrid_builder/tests/test_grid.py
+++ b/threedigrid_builder/tests/test_grid.py
@@ -45,7 +45,6 @@ def meta():
             grid_space=20.0,
             dist_calc_points=25.0,
             kmax=4,
-            initial_waterlevel=-0.4,
         ),
         tables_settings=TablesSettings(
             table_step_size=0.05,
@@ -211,11 +210,8 @@ def test_set_initial_waterlevels(compute_initial_waterlevels, grid):
     channels = mock.Mock()
     pipes = mock.Mock()
     culverts = mock.Mock()
-    global_initial_waterlevel = 42.0
 
-    grid.set_initial_waterlevels(
-        connection_nodes, channels, pipes, culverts, global_initial_waterlevel
-    )
+    grid.set_initial_waterlevels(connection_nodes, channels, pipes, culverts)
 
     compute_initial_waterlevels.assert_called_with(
         grid.nodes,
@@ -223,7 +219,6 @@ def test_set_initial_waterlevels(compute_initial_waterlevels, grid):
         channels=channels,
         pipes=pipes,
         culverts=culverts,
-        global_initial_waterlevel=global_initial_waterlevel,
     )
 
 

--- a/threedigrid_builder/tests/test_gridadmin.py
+++ b/threedigrid_builder/tests/test_gridadmin.py
@@ -49,7 +49,6 @@ def h5_out(tmpdir_factory):
             grid_space=20.0,
             dist_calc_points=25.0,
             kmax=4,
-            initial_waterlevel=-0.4,
         ),
         tables_settings=TablesSettings(
             table_step_size=0.05,
@@ -293,6 +292,7 @@ def test_write_meta(h5_out, dataset, shape, dtype):
         ("has_pumpstations", (), "bool"),  # changed to bool
         ("has_simple_infiltration", (), "bool"),  # changed to bool
         ("has_interflow", (), "bool"),  # added
+        ("has_initial_waterlevels", (), "bool"),  # added
         ("model_name", (), "S"),
         ("model_slug", (), "S"),
         ("revision_hash", (), "S"),

--- a/threedigrid_builder/tests/test_initial_waterlevels.py
+++ b/threedigrid_builder/tests/test_initial_waterlevels.py
@@ -49,7 +49,6 @@ def connection_nodes():
 @pytest.mark.parametrize(
     "initial_waterlevels, expected",
     [
-        ([nan, nan, nan, nan, nan], [42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0]),
         ([0.0, 0.0, 0.0, 0.0, 0.0], [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),
         ([1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
         ([1.0, nan, nan, nan, nan], [1.0, 0.2, 0.3, 0.867, 0.733, 0.6, 0.9, 0.8]),
@@ -67,7 +66,6 @@ def test_compute_initial_waterlevels(
         channels=channels,
         pipes=mock.Mock(),
         culverts=mock.Mock(),
-        global_initial_waterlevel=42.0,
     )
 
     assert_almost_equal(nodes.initial_waterlevel, expected, decimal=3)


### PR DESCRIPTION
With this you can check ["meta"]["has_initial_waterlevels"] to check whether to use a global or per-node value for the initial waterlevels.

Also the global value itself is not used anymore. I considered that that should go through the scenario settings worker, and not through the gridadmin. For the testbank, we can (for now) use the ini setting (as it is still done in https://github.com/nens/threedi-calculationcore/pull/513)