### PR TITLE
[DONE] Use DEM epsg_code for 2D models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedigrid-builder
 0.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Bugfix: use DEM epsg_code for 2D models.
 
 
 0.9.0 (2021-12-15)

--- a/threedigrid_builder/application.py
+++ b/threedigrid_builder/application.py
@@ -68,6 +68,9 @@ def _make_gridadmin(
         # Patch epsg code with that of the DEM (so: user-supplied EPSG is ignored)
         grid.meta.epsg_code = raster.epsg_code
 
+        # Use raster epsg_code instead of the one from global_settings
+        db.epsg_code = raster.epsg_code
+
         refinements = db.get_grid_refinements()
         progress_callback(0.7, "Constructing 2D computational grid...")
         quadtree = QuadTree(

--- a/threedigrid_builder/base/interfaces.py
+++ b/threedigrid_builder/base/interfaces.py
@@ -66,7 +66,7 @@ class RasterInterface(ABC):
 
         self.transform = (a, b, c, d, e, f)
 
-    def set_epsg_code(self, epsg_code):
+    def set_epsg_code(self, epsg_code: int):
         self.epsg_code = epsg_code
 
     @property

--- a/threedigrid_builder/interface/db.py
+++ b/threedigrid_builder/interface/db.py
@@ -239,6 +239,10 @@ class SQLite:
             self._epsg_code = self.get_settings()["epsg_code"]
         return self._epsg_code
 
+    @epsg_code.setter
+    def epsg_code(self, value: int):
+        self._epsg_code = value
+
     def reproject(self, geometries: np.ndarray) -> np.ndarray:
         """Reproject geometries from 4326 to the EPSG in the settings.
 

--- a/threedigrid_builder/interface/raster_rasterio.py
+++ b/threedigrid_builder/interface/raster_rasterio.py
@@ -25,7 +25,7 @@ def get_epsg_code(crs):
         raise SchematisationError(
             f"The supplied DEM file has a non-EPSG projection '{str(crs)}'"
         )
-    return crs.to_epsg()
+    return int(crs.to_epsg())
 
 
 class RasterioInterface(RasterInterface):


### PR DESCRIPTION
espg_code can be "None" (null) in global_settings.

Problem found in: demo_org_noordpolder - noordpolder - 1 default
https://api.staging.3di.live/v3/threedimodels/14669/


Sentry: https://sentry.io/organizations/nens/issues/2862273109/?project=1496857&query=is%3Aunresolved