### PR TITLE
[Done] 1D remaining fields crest level and type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog of threedigrid-builder
 0.15.1 (unreleased)
 -------------------
 
+- Added crest level and crest type to to lines.
+
 - Added connection node start and end id to lines.
 
 - Handle non-ASCII characters in gridadmin HDF5 output.

--- a/threedigrid_builder/base/lines.py
+++ b/threedigrid_builder/base/lines.py
@@ -1,4 +1,5 @@
 from .array import array_of
+from threedigrid_builder.constants import CalculationType
 from threedigrid_builder.constants import ContentType
 from threedigrid_builder.constants import LineType
 from typing import Tuple
@@ -45,6 +46,8 @@ class Line:
     zoom_category: int
     connection_node_start_id: int
     connection_node_end_id: int
+    crest_level: float
+    crest_type: CalculationType
 
 
 @array_of(Line)

--- a/threedigrid_builder/grid/structures.py
+++ b/threedigrid_builder/grid/structures.py
@@ -132,6 +132,8 @@ class WeirOrifices:
             display_name=self.display_name,
             connection_node_start_id=self.connection_node_start_id,
             connection_node_end_id=self.connection_node_end_id,
+            crest_level=self.crest_level,
+            crest_type=self.crest_type,
         )
 
 

--- a/threedigrid_builder/interface/gridadmin.py
+++ b/threedigrid_builder/interface/gridadmin.py
@@ -467,10 +467,10 @@ class GridAdminOut(OutputInterface):
         self.write_dataset(
             group, "connection_node_start_pk", lines.connection_node_end_id
         )
+        self.write_dataset(group, "crest_level", lines.crest_level)
+        self.write_dataset(group, "crest_type", lines.crest_type)
 
         # can be collected from SQLite, but empty for now:
-        self.write_dataset(group, "crest_level", fill_float)
-        self.write_dataset(group, "crest_type", fill_int)
         self.write_dataset(group, "cross_section_height", fill_int)
         self.write_dataset(group, "cross_section_shape", fill_int)
         self.write_dataset(group, "cross_section_width", fill_float)


### PR DESCRIPTION
Weirs & Orifices have `crest_level` and `crest_type`
Obstacles and Levees have `crest_level`

For obstacles the `crest_level` is used to write `flod` and `flou`, I assume we don't write `crest_level` there. 