### PR TITLE
293 allow connected objects partially outside of the dem

### DIFF
--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -805,7 +805,7 @@ class Grid:
         # if one of the nodes is null, the numpy id reset will silently overflow and assign a
         # different new id, leading to an incorrect result
         if np.any(self.lines.line == -9999):
-            raise ValueError("Some lines are not fully connected to nodes")
+            raise ValueError("Some lines are not fully connected to nodes, causing a null value to be set for the line node")
 
         node_sorter = np.concatenate(
             [np.where(np.isin(self.nodes.node_type, group))[0] for group in NODE_ORDER]

--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -805,7 +805,9 @@ class Grid:
         # if one of the nodes is null, the numpy id reset will silently overflow and assign a
         # different new id, leading to an incorrect result
         if np.any(self.lines.line == -9999):
-            raise ValueError("Some lines are not fully connected to nodes, causing a null value to be set for the line node")
+            raise ValueError(
+                "Some lines are not fully connected to nodes, causing a null value to be set for the line node"
+            )
 
         node_sorter = np.concatenate(
             [np.where(np.isin(self.nodes.node_type, group))[0] for group in NODE_ORDER]

--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -801,6 +801,11 @@ class Grid:
 
         See NODE_ORDER and LINE_ORDER for the order.
         """
+        # if one of the nodes is null, the numpy id reset will silently overflow and assign a
+        # different new id, leading to an incorrect result
+        if np.any(self.lines.line == -9999):
+            raise ValueError("Some lines are not fully connected to nodes")
+
         node_sorter = np.concatenate(
             [np.where(np.isin(self.nodes.node_type, group))[0] for group in NODE_ORDER]
         )

--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -698,6 +698,7 @@ class Grid:
         lines_1d2d.assign_2d_side_from_exchange_lines(exchange_lines)
         lines_1d2d.assign_breaches(self.nodes, potential_breaches)
         lines_1d2d.assign_2d_node(self.cell_tree)
+        lines_1d2d.remove_unassigned(self.nodes)
         lines_1d2d.set_line_coords(self.nodes)
         lines_1d2d.fix_line_geometries()
         lines_1d2d.assign_dpumax_from_breaches(potential_breaches)

--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -698,7 +698,7 @@ class Grid:
         lines_1d2d.assign_2d_side_from_exchange_lines(exchange_lines)
         lines_1d2d.assign_breaches(self.nodes, potential_breaches)
         lines_1d2d.assign_2d_node(self.cell_tree)
-        lines_1d2d.remove_unassigned(self.nodes)
+        lines_1d2d = lines_1d2d.remove_unassigned(self.nodes)
         lines_1d2d.set_line_coords(self.nodes)
         lines_1d2d.fix_line_geometries()
         lines_1d2d.assign_dpumax_from_breaches(potential_breaches)

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -286,19 +286,17 @@ class Lines1D2D(Lines):
         """Removes 1D-2D lines where any of the required nodes is set to null, represented as -9999
         This is the case when the nodes are outside the 2D domain.
         """
-        rows_removed = self[np.where(self.line[:, 0] == -9999)]
-        nodes_removed = nodes.id_to_index(rows_removed.line[:, 1])
+        rows_removed = self.line[:, 0] == -9999
+        node_ids_removed = self.line[rows_removed, 1]
+        nodes_removed = nodes.id_to_index(node_ids_removed)
         nodes_removed_formatted = nodes.format_message(nodes_removed)
 
         logger.warning(
-            f"Removing {len(rows_removed)} 1D-2D lines attached to {nodes_removed_formatted} because they are outside of the DEM."
+            f"Removing {len(node_ids_removed)} 1D-2D lines attached to {nodes_removed_formatted} because they are outside of the DEM."
         )
 
-        new_array = self[np.where(self.line[:, 0] != -9999)]
-        # overwrite all columns of self with the columns of the array where rows with null nodes are deleted
-        for k, v in vars(new_array).items():
-            setattr(self, k, v)
-        pass
+        new_array = self[self.line[:, 0] != -9999]
+        return new_array
 
     def transfer_2d_node_to_groundwater(self, offset: int):
         """Transfers the 1D-2D line to a groundwater node

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -290,7 +290,7 @@ class Lines1D2D(Lines):
         nodes_removed = nodes.id_to_index(rows_removed.line[:, 1])
         nodes_removed_formatted = nodes.format_message(nodes_removed)
 
-        logger.warn(
+        logger.warning(
             f"Removing {len(rows_removed)} 1D-2D lines attached to {nodes_removed_formatted} because they are outside of the DEM."
         )
 

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 from typing import Iterator
 
 import numpy as np
@@ -14,6 +15,8 @@ from .linear import BaseLinear
 from .obstacles import Obstacles
 from .pipes import Pipes
 from .potential_breaches import PotentialBreaches
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["Lines1D2D"]
 
@@ -278,6 +281,24 @@ class Lines1D2D(Lines):
         line_idx, cell_idx = idx[:, unique_matches]
         self.line[line_idx, 0] = cell_idx
         self.line_coords[:] = np.nan
+
+    def remove_unassigned(self, nodes) -> None:
+        """Removes 1D-2D lines where any of the required nodes is set to null, represented as -9999
+        This is the case when the nodes are outside the 2D domain.
+        """
+        rows_removed = self[np.where(self.line[:, 0] == -9999)]
+        nodes_removed = nodes.id_to_index(rows_removed.line[:, 1])
+        nodes_removed_formatted = nodes.format_message(nodes_removed)
+
+        logger.warn(
+            f"Removing {len(rows_removed)} 1D-2D lines attached to {nodes_removed_formatted} because they are outside of the DEM."
+        )
+
+        new_array = self[np.where(self.line[:, 0] != -9999)]
+        # overwrite all columns of self with the columns of the array where rows with null nodes are deleted
+        for k, v in vars(new_array).items():
+            setattr(self, k, v)
+        pass
 
     def transfer_2d_node_to_groundwater(self, offset: int):
         """Transfers the 1D-2D line to a groundwater node

--- a/threedigrid_builder/tests/test_grid.py
+++ b/threedigrid_builder/tests/test_grid.py
@@ -287,6 +287,12 @@ def test_sort_no_lines(grid_for_sorting):
     grid_for_sorting.sort()
 
 
+def test_sort_null_lines(grid_for_sorting):
+    grid_for_sorting.lines.line[0] = (-9999, 2)
+    with pytest.raises(ValueError):
+        grid_for_sorting.sort()
+
+
 def test_sort_boundary_conditions():
     grid = Grid(
         Nodes(

--- a/threedigrid_builder/tests/test_grid.py
+++ b/threedigrid_builder/tests/test_grid.py
@@ -287,7 +287,7 @@ def test_sort_no_lines(grid_for_sorting):
     grid_for_sorting.sort()
 
 
-def test_sort_null_lines(grid_for_sorting):
+def test_sort_null_lines_err(grid_for_sorting):
     grid_for_sorting.lines.line[0] = (-9999, 2)
     with pytest.raises(ValueError):
         grid_for_sorting.sort()

--- a/threedigrid_builder/tests/test_lines_1d2d.py
+++ b/threedigrid_builder/tests/test_lines_1d2d.py
@@ -184,7 +184,7 @@ def test_remove_line_unassigned_nodes():
     lines = Lines1D2D(
         id=[1, 2], line=[(-9999, 1), (1, 2)], line_coords=[(10, 0, 0, 0), (5, 2, 3, 8)]
     )
-    lines.remove_unassigned(nodes)
+    lines = lines.remove_unassigned(nodes)
     assert lines.id == [2]
     assert (lines.line == [(1, 2)]).all()
     assert (lines.line_coords == [(5, 2, 3, 8)]).all()

--- a/threedigrid_builder/tests/test_lines_1d2d.py
+++ b/threedigrid_builder/tests/test_lines_1d2d.py
@@ -179,6 +179,18 @@ def test_assign_2d_node(side_2d_coordinates, expected_2d_node_id, cell_tree):
     assert_array_equal(lines.line_coords, np.nan)  # is cleared
 
 
+def test_remove_line_unassigned_nodes():
+    nodes = Nodes(id=[1, 2])
+    lines = Lines1D2D(
+        id=[1, 2], line=[(-9999, 1), (1, 2)], line_coords=[(10, 0, 0, 0), (5, 2, 3, 8)]
+    )
+    lines.remove_unassigned(nodes)
+    assert lines.id == [2]
+    assert (lines.line == [(1, 2)]).all()
+    assert (lines.line_coords == [(5, 2, 3, 8)]).all()
+    pass
+
+
 def test_assign_kcu():
     lines = Lines1D2D(id=range(7), line=[[-9999] + [x] for x in [1, 1, 2, 2, 3, 4, 5]])
     lines.content_type[0] = ContentType.TYPE_V2_BREACH

--- a/threedigrid_builder/tests/test_lines_1d2d.py
+++ b/threedigrid_builder/tests/test_lines_1d2d.py
@@ -185,10 +185,9 @@ def test_remove_line_unassigned_nodes():
         id=[1, 2], line=[(-9999, 1), (1, 2)], line_coords=[(10, 0, 0, 0), (5, 2, 3, 8)]
     )
     lines = lines.remove_unassigned(nodes)
-    assert lines.id == [2]
-    assert (lines.line == [(1, 2)]).all()
-    assert (lines.line_coords == [(5, 2, 3, 8)]).all()
-    pass
+    np.testing.assert_equal(lines.id, [2])
+    np.testing.assert_equal(lines.line, [(1, 2)])
+    np.testing.assert_equal(lines.line_coords, [(5, 2, 3, 8)])
 
 
 def test_assign_kcu():


### PR DESCRIPTION
Adds an error when a line with null nodes is passed into sort, and removes those lines earlier in the grid building process. Outputs a warning when those lines are removed.