### PR TITLE
310 the exchange level of all 1d 2d lines must be adapted if it crosses an obstacle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Changelog of threedigrid-builder
 - Add Python 3.11 and SQLAlchemy 2.0 support, drop SQLAlchemy 1.3.
 - Allow connected objects outside the DEM, by removing 1D-2D connections which are outside the DEM
 
+- Reassign 1D-2D geometries based on nodes for all open water lines, not just exchange lines and breaches.
+
+- Set exchange level for all these lines based on obstacles crossed.
+
 
 1.8.0 (2023-01-19)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog of threedigrid-builder
 - Reassign 1D-2D geometries for all open water lines, not just exchange lines and breaches, as follows:
   
   for potential_breaches, the actual line inserted by the user
+
   for others the line from the 1D node to the 2D cell center
 
 - Set exchange level for all these lines based on obstacles crossed.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,10 @@ Changelog of threedigrid-builder
 - Add Python 3.11 and SQLAlchemy 2.0 support, drop SQLAlchemy 1.3.
 - Allow connected objects outside the DEM, by removing 1D-2D connections which are outside the DEM
 
-- Reassign 1D-2D geometries based on nodes for all open water lines, not just exchange lines and breaches.
+- Reassign 1D-2D geometries for all open water lines, not just exchange lines and breaches, as follows:
+  
+  for potential_breaches, the actual line inserted by the user
+  for others the line from the 1D node to the 2D cell center
 
 - Set exchange level for all these lines based on obstacles crossed.
 

--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -701,15 +701,19 @@ class Grid:
         lines_1d2d = lines_1d2d.remove_unassigned(self.nodes)
         lines_1d2d.set_line_coords(self.nodes)
         lines_1d2d.fix_line_geometries()
-        lines_1d2d.assign_dpumax_from_breaches(potential_breaches)
-        lines_1d2d.assign_dpumax_from_exchange_lines(exchange_lines)
-        lines_1d2d.assign_dpumax_from_obstacles(self.obstacles)
         # Go through objects and dispatch to get_1d2d_properties
         node_idx = lines_1d2d.get_1d_node_idx(self.nodes)
         for objects in (channels, connection_nodes, pipes, culverts):
             mask = self.nodes.content_type[node_idx] == objects.content_type
             content_pk = self.nodes.content_pk[node_idx[mask]]
             lines_1d2d.assign_kcu(mask, objects.is_closed(content_pk))
+        lines_1d2d.assign_dpumax_from_breaches(potential_breaches)
+        lines_1d2d.assign_dpumax_from_exchange_lines(exchange_lines)
+        lines_1d2d.assign_dpumax_from_obstacles(self.obstacles)
+        # Go through objects and dispatch to get_1d2d_properties
+        for objects in (channels, connection_nodes, pipes, culverts):
+            mask = self.nodes.content_type[node_idx] == objects.content_type
+            content_pk = self.nodes.content_pk[node_idx[mask]]
             lines_1d2d.assign_dpumax(
                 mask,
                 objects.get_1d2d_exchange_levels(

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -177,7 +177,7 @@ class Lines1D2D(Lines):
         """Compute the closest Point on exchange line for each 1D2D line
 
         Requires: line_coords[:, 2:] (side_1d), content_pk, content_type
-        Sets: line_coords[:, :2] (side_2d), line_geometries
+        Sets: line_coords[:, :2] (side_2d)
         """
         # Create an array of node indices & corresponding exchange line indices
         has_exc = self.content_type == ContentType.TYPE_V2_EXCHANGE_LINE
@@ -192,7 +192,6 @@ class Lines1D2D(Lines):
         self.line_coords[has_exc, :2] = shapely.get_coordinates(
             shapely.get_point(line_geom, 0)
         )
-        self.line_geometries[has_exc] = line_geom
 
     def assign_breaches(self, nodes: Nodes, potential_breaches: PotentialBreaches):
         """Assign breaches to the 1D-2D lines.
@@ -355,18 +354,18 @@ class Lines1D2D(Lines):
 
         Requires line_geometries.
         """
-        is_displaced = np.isin(
-            self.content_type,
-            [ContentType.TYPE_V2_EXCHANGE_LINE, ContentType.TYPE_V2_BREACH],
+        is_open_water = np.isin(
+            self.kcu,
+            [LineType.LINE_1D2D_SINGLE_CONNECTED_OPEN_WATER, LineType.LINE_1D2D_DOUBLE_CONNECTED_OPEN_WATER],
         )
-        is_displaced_idx = np.where(is_displaced)[0]
+        is_open_water_idx = np.where(is_open_water)[0]
         obstacle_crest_levels, obstacle_idx = obstacles.compute_dpumax(
-            self, where=is_displaced_idx
+            self, where=is_open_water_idx
         )
-        self.assign_dpumax(is_displaced, obstacle_crest_levels)
+        self.assign_dpumax(is_open_water, obstacle_crest_levels)
         mask = obstacle_idx != -9999
         self.assign_ds1d_half_from_obstacles(
-            obstacles, is_displaced_idx[mask], obstacle_idx[mask]
+            obstacles, is_open_water_idx[mask], obstacle_idx[mask]
         )
 
     def assign_ds1d_half_from_obstacles(

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -282,21 +282,24 @@ class Lines1D2D(Lines):
         self.line[line_idx, 0] = cell_idx
         self.line_coords[:] = np.nan
 
-    def remove_unassigned(self, nodes) -> None:
+    def remove_unassigned(self, nodes) -> "Lines1D2D":
         """Removes 1D-2D lines where any of the required nodes is set to null, represented as -9999
         This is the case when the nodes are outside the 2D domain.
         """
         rows_removed = self.line[:, 0] == -9999
         node_ids_removed = self.line[rows_removed, 1]
-        nodes_removed = nodes.id_to_index(node_ids_removed)
-        nodes_removed_formatted = nodes.format_message(nodes_removed)
+        if len(node_ids_removed) > 0:
+            nodes_removed = nodes.id_to_index(node_ids_removed)
+            nodes_removed_formatted = nodes.format_message(nodes_removed)
 
-        logger.warning(
-            f"Removing {len(node_ids_removed)} 1D-2D lines attached to {nodes_removed_formatted} because they are outside of the DEM."
-        )
+            logger.warning(
+                f"Removing {len(node_ids_removed)} 1D-2D lines attached to {nodes_removed_formatted} because they are outside of the DEM."
+            )
 
-        new_array = self[self.line[:, 0] != -9999]
-        return new_array
+            new_array = self[self.line[:, 0] != -9999]
+            return new_array
+        else:
+            return self
 
     def transfer_2d_node_to_groundwater(self, offset: int):
         """Transfers the 1D-2D line to a groundwater node

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -350,9 +350,7 @@ class Lines1D2D(Lines):
     def assign_dpumax_from_obstacles(self, obstacles: Obstacles):
         """Set the dpumax based on intersected obstacles
 
-        Only for (open) connections that are computed via an exchange line or breach.
-
-        Requires line_geometries.
+        Only for open connections. Requires line_geometries.
         """
         is_open_water = np.isin(
             self.kcu,

--- a/threedigrid_builder/tests/test_lines_1d2d.py
+++ b/threedigrid_builder/tests/test_lines_1d2d.py
@@ -286,7 +286,14 @@ def test_assign_dpumax_from_obstacles(
         np.array([1, -9999]),
     )
 
-    lines = Lines1D2D(id=range(3), content_type=[EXC, -9999, EXC])
+    lines = Lines1D2D(
+        id=range(3),
+        kcu=[
+            LineType.LINE_1D2D_SINGLE_CONNECTED_OPEN_WATER,
+            LineType.LINE_1D2D_SINGLE_CONNECTED_CLOSED,
+            LineType.LINE_1D2D_SINGLE_CONNECTED_OPEN_WATER,
+        ],
+    )
 
     lines.assign_dpumax_from_obstacles(obstacles)
 


### PR DESCRIPTION
Change geometries for all open water 1D-2D connection lines:
for potential_breaches, the actual line inserted by the user
for others the line from the 1D node to the 2D cell center

Calculate exchange level for these lines based on the obstacles they cross.