### PR TITLE
293 raise error on connected objects outside the dem

### DIFF
--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -698,7 +698,7 @@ class Grid:
         lines_1d2d.assign_2d_side_from_exchange_lines(exchange_lines)
         lines_1d2d.assign_breaches(self.nodes, potential_breaches)
         lines_1d2d.assign_2d_node(self.cell_tree)
-        lines_1d2d = lines_1d2d.remove_unassigned(self.nodes)
+        lines_1d2d.check_unassigned(self.nodes)
         lines_1d2d.set_line_coords(self.nodes)
         lines_1d2d.fix_line_geometries()
         # Go through objects and dispatch to get_1d2d_properties

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -287,8 +287,8 @@ class Lines1D2D(Lines):
         This is the case when the nodes are outside the 2D domain.
         """
         invalid_rows = self.line[:, 0] == -9999
-        invalid_node_ids = self.line[invalid_rows, 1]
-        if invalid_node_ids.any():
+        if invalid_rows.any():
+            invalid_node_ids = self.line[invalid_rows, 1]
             invalid_nodes = nodes.id_to_index(invalid_node_ids)
             invalid_nodes_formatted = nodes.format_message(invalid_nodes)
 

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -288,7 +288,7 @@ class Lines1D2D(Lines):
         """
         invalid_rows = self.line[:, 0] == -9999
         invalid_node_ids = self.line[invalid_rows, 1]
-        if len(invalid_node_ids) > 0:
+        if invalid_node_ids.any():
             invalid_nodes = nodes.id_to_index(invalid_node_ids)
             invalid_nodes_formatted = nodes.format_message(invalid_nodes)
 

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -282,7 +282,7 @@ class Lines1D2D(Lines):
         self.line[line_idx, 0] = cell_idx
         self.line_coords[:] = np.nan
 
-    def check_unassigned(self, nodes) -> "Lines1D2D":
+    def check_unassigned(self, nodes) -> None:
         """Checks 1D-2D lines where any of the required nodes is set to null, represented as -9999
         This is the case when the nodes are outside the 2D domain.
         """

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -7,6 +7,7 @@ import shapely
 
 from threedigrid_builder.base import LineHalfs, Lines, Nodes, replace, search
 from threedigrid_builder.constants import CalculationType, ContentType, LineType
+from threedigrid_builder.exceptions import SchematisationError
 
 from .channels import Channels
 from .connection_nodes import ConnectionNodes
@@ -281,24 +282,19 @@ class Lines1D2D(Lines):
         self.line[line_idx, 0] = cell_idx
         self.line_coords[:] = np.nan
 
-    def remove_unassigned(self, nodes) -> "Lines1D2D":
-        """Removes 1D-2D lines where any of the required nodes is set to null, represented as -9999
+    def check_unassigned(self, nodes) -> "Lines1D2D":
+        """Checks 1D-2D lines where any of the required nodes is set to null, represented as -9999
         This is the case when the nodes are outside the 2D domain.
         """
-        rows_removed = self.line[:, 0] == -9999
-        node_ids_removed = self.line[rows_removed, 1]
-        if len(node_ids_removed) > 0:
-            nodes_removed = nodes.id_to_index(node_ids_removed)
-            nodes_removed_formatted = nodes.format_message(nodes_removed)
+        invalid_rows = self.line[:, 0] == -9999
+        invalid_node_ids = self.line[invalid_rows, 1]
+        if len(invalid_node_ids) > 0:
+            invalid_nodes = nodes.id_to_index(invalid_node_ids)
+            invalid_nodes_formatted = nodes.format_message(invalid_nodes)
 
-            logger.warning(
-                f"Removing {len(node_ids_removed)} 1D-2D lines attached to {nodes_removed_formatted} because they are outside of the DEM."
+            raise SchematisationError(
+                f"The following {invalid_nodes_formatted} are outside of the DEM, but are connected to an object which does not have an ISOLATED calculation type."
             )
-
-            new_array = self[self.line[:, 0] != -9999]
-            return new_array
-        else:
-            return self
 
     def transfer_2d_node_to_groundwater(self, offset: int):
         """Transfers the 1D-2D line to a groundwater node

--- a/threedigrid_builder/grid/lines_1d2d.py
+++ b/threedigrid_builder/grid/lines_1d2d.py
@@ -293,7 +293,7 @@ class Lines1D2D(Lines):
             invalid_nodes_formatted = nodes.format_message(invalid_nodes)
 
             raise SchematisationError(
-                f"The following {invalid_nodes_formatted} are outside of the DEM, but are connected to an object which does not have an ISOLATED calculation type."
+                f"The following objects are connected but are (partially) outside of the 2D model domain: {invalid_nodes_formatted}."
             )
 
     def transfer_2d_node_to_groundwater(self, offset: int):

--- a/threedigrid_builder/tests/test_lines_1d2d.py
+++ b/threedigrid_builder/tests/test_lines_1d2d.py
@@ -197,7 +197,7 @@ def test_assign_2d_node(side_2d_coordinates, expected_2d_node_id, cell_tree):
             pytest.raises(
                 SchematisationError,
                 match=re.escape(
-                    "1 1D-2D lines attached to connection nodes [5] are outside of the DEM."
+                    "The following connection nodes [5] are outside of the DEM, but are connected to an object which does not have an ISOLATED calculation type."
                 ),
             ),
         ),

--- a/threedigrid_builder/tests/test_lines_1d2d.py
+++ b/threedigrid_builder/tests/test_lines_1d2d.py
@@ -197,7 +197,7 @@ def test_assign_2d_node(side_2d_coordinates, expected_2d_node_id, cell_tree):
             pytest.raises(
                 SchematisationError,
                 match=re.escape(
-                    "The following connection nodes [5] are outside of the DEM, but are connected to an object which does not have an ISOLATED calculation type."
+                    "The following objects are connected but are (partially) outside of the 2D model domain: connection nodes [5]."
                 ),
             ),
         ),

--- a/threedigrid_builder/tests/test_lines_1d2d.py
+++ b/threedigrid_builder/tests/test_lines_1d2d.py
@@ -1,4 +1,6 @@
 import itertools
+import re
+from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import numpy as np
@@ -9,6 +11,7 @@ from shapely.testing import assert_geometries_equal
 
 from threedigrid_builder.base import Lines, Nodes
 from threedigrid_builder.constants import CalculationType, ContentType, LineType
+from threedigrid_builder.exceptions import SchematisationError
 from threedigrid_builder.grid import (
     Channels,
     ConnectionNodes,
@@ -179,15 +182,41 @@ def test_assign_2d_node(side_2d_coordinates, expected_2d_node_id, cell_tree):
     assert_array_equal(lines.line_coords, np.nan)  # is cleared
 
 
-def test_remove_line_unassigned_nodes():
-    nodes = Nodes(id=[1, 2])
-    lines = Lines1D2D(
-        id=[1, 2], line=[(-9999, 1), (1, 2)], line_coords=[(10, 0, 0, 0), (5, 2, 3, 8)]
-    )
-    lines = lines.remove_unassigned(nodes)
-    np.testing.assert_equal(lines.id, [2])
-    np.testing.assert_equal(lines.line, [(1, 2)])
-    np.testing.assert_equal(lines.line_coords, [(5, 2, 3, 8)])
+@pytest.mark.parametrize(
+    "nodes,lines,expectation",
+    [
+        (
+            Nodes(
+                id=[1, 2], content_type=[12, 12], content_pk=[5, 6], node_type=[4, 4]
+            ),
+            Lines1D2D(
+                id=[3, 4],
+                line=[(-9999, 1), (1, 2)],
+                line_coords=[(10, 0, 0, 0), (5, 2, 3, 8)],
+            ),
+            pytest.raises(
+                SchematisationError,
+                match=re.escape(
+                    "1 1D-2D lines attached to connection nodes [5] are outside of the DEM."
+                ),
+            ),
+        ),
+        (
+            Nodes(
+                id=[1, 2], content_type=[12, 12], content_pk=[5, 6], node_type=[4, 4]
+            ),
+            Lines1D2D(
+                id=[3, 4],
+                line=[(2, 1), (1, 2)],
+                line_coords=[(10, 0, 0, 0), (5, 2, 3, 8)],
+            ),
+            does_not_raise(),
+        ),
+    ],
+)
+def test_check_line_unassigned_nodes(nodes, lines, expectation):
+    with expectation:
+        lines.check_unassigned(nodes)
 
 
 def test_assign_kcu():


### PR DESCRIPTION
This raises a SchematisationError when an object is not of an ISOLATED type, and is also connected to a node outside of the DEM.