### PR TITLE
Use pyproject.toml where possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,4 +93,4 @@ norecursedirs = [
 ]
 python_files = ["test_*.py"]
 testpaths = ["threedigrid_builder"]
-filterwarnings = ["error::numpy"]
+filterwarnings = ["error:::numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ zip-safe = false
 [tool.setuptools.dynamic]
 version = {attr = "threedigrid_builder.__version__"}
 
-[tool.setuptools.packages]
+[tool.setuptools.packages.find]
 include = [
     "threedigrid_builder",
     "threedigrid_builder.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,46 @@
+[project]
+name = "threedigrid-builder"
+authors = [
+    {name = "Martijn Siemerink", email = "martijn.siemerink@nelen-schuurmans.nl"}
+]
+description = "Generate a 3Di simulation grid from a model schematisation."
+readme = "README.rst"
+requires-python = ">=3.7"
+license = {text = "GNU General Public License v3.0"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Development Status :: 5 - Production/Stable",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "License :: Other/Proprietary License",
+]
+dependencies = [
+    "numpy>=1.15,<1.25.0",
+    "threedi-schema>=0.217.0",
+    "shapely>=2",
+    "pyproj>=3",
+    "condenser[geo]>=0.1.1",
+    "sqlalchemy>=1.4.1",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+test = ["pytest", "pytest-cov"]
+gridadmin = ["h5py>=2.7"]
+gpkg = ["geopandas"]
+cli = ["typer"]
+
+[project.urls]
+Documentation = "https://docs.3di.lizard.net/"
+
+[project.scripts]
+threedigrid-builder = "threedigrid_builder.cli:run"
+
 [build-system]
 # numpy required to execute setup.py
 requires = [
@@ -16,3 +59,37 @@ requires = [
     "numpy; python_version>='3.11'",
     "ninja; platform_system!='Windows'"
 ]
+
+[tool.setuptools]
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.dynamic]
+version = {attr = "threedigrid_builder.__version__"}
+
+[tool.setuptools.packages]
+include = [
+    "threedigrid_builder",
+    "threedigrid_builder.*",
+]
+
+[tool.isort]
+profile = "black"
+force_alphabetical_sort_within_sections = true
+
+[tool.pytest.ini_options]
+norecursedirs = [
+    ".venv",
+    "data",
+    "doc",
+    "etc",
+    "*.egg-info",
+    "misc",
+    "var",
+    "build",
+    "lib",
+    "include",
+]
+python_files = ["test_*.py"]
+testpaths = ["threedigrid_builder"]
+filterwarnings = ["error::numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,18 +61,8 @@ requires = [
     "ninja; platform_system!='Windows'"
 ]
 
-[tool.setuptools]
-include-package-data = true
-zip-safe = false
-
 [tool.setuptools.dynamic]
 version = {attr = "threedigrid_builder.__version__"}
-
-[tool.setuptools.packages.find]
-include = [
-    "threedigrid_builder",
-    "threedigrid_builder.*",
-]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ cli = ["typer"]
 
 [project.urls]
 Documentation = "https://docs.3di.lizard.net/"
+Repository = "https://github.com/nens/threedigrid-builder"
 
 [project.scripts]
 threedigrid-builder = "threedigrid_builder.cli:run"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-ipython
-jupyterlab
-ipdb
-ipywidgets
-matplotlib
-jedi==0.17.2
-h5py
-pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,15 +6,3 @@ python-file-with-version = threedigrid_builder/__init__.py
 exclude = docs
 max-line-length = 88
 ignore = E203, E266, E501, W503
-
-[tool:isort]
-profile = black
-force_alphabetical_sort_within_sections = true
-
-[tool:pytest]
-norecursedirs = .venv data doc etc *.egg-info misc var build lib include
-python_files = test_*.py
-testpaths =
-    threedigrid_builder
-filterwarnings =
-    error:::numpy

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ import pathlib
 import shutil
 import sys
 
-from setuptools import find_packages
-
 try:
     from skbuild import setup
 except ImportError:
@@ -36,70 +34,6 @@ if sys.platform == "win32":
 else:
     cmake_args = []
 
-long_description = open("README.rst").read()
-
-
-def get_version():
-    # Edited from https://packaging.python.org/guides/single-sourcing-package-version/
-    init_path = pathlib.Path(__file__).parent / "threedigrid_builder/__init__.py"
-    for line in init_path.open("r").readlines():
-        if line.startswith("__version__"):
-            delim = '"' if '"' in line else "'"
-            return line.split(delim)[1]
-    else:
-        raise RuntimeError("Unable to find version string.")
-
-
-install_requires = [
-    "numpy>=1.15,<1.25.0",
-    "threedi-schema>=0.217.0",
-    "shapely>=2",
-    "pyproj>=3",
-    "condenser[geo]>=0.1.1",
-    "sqlalchemy>=1.4.1",
-]
-
-test_requires = ["pytest", "pytest-cov"]
-
 setup(
-    name="threedigrid-builder",
-    version=get_version(),
-    description="Generate a 3Di simulation grid from a model schematisation.",
-    long_description=long_description,
-    url="https://docs.3di.lizard.net/",
-    author="Martijn Siemerink",
-    author_email="martijn.siemerink@nelen-schuurmans.nl",
-    license="GNU General Public License v3.0",
-    packages=find_packages(
-        include=(
-            "threedigrid_builder",
-            "threedigrid_builder.*",
-        ),
-    ),
     cmake_args=cmake_args,
-    install_requires=install_requires,
-    extras_require={
-        "test": test_requires,
-        "gridadmin": ["h5py>=2.7"],
-        "gpkg": ["geopandas"],
-        "cli": ["typer"],
-    },
-    python_requires=">=3.7",
-    include_package_data=True,
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: Developers",
-        "Development Status :: 5 - Production/Stable",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Software Development",
-        "Operating System :: Unix",
-        "Operating System :: MacOS",
-        "Operating System :: Microsoft :: Windows",
-        "License :: Other/Proprietary License",
-    ],
-    zip_safe=False,
-    entry_points={
-        "console_scripts": ["threedigrid-builder=threedigrid_builder.cli:run"],
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import pathlib
 import shutil
 import sys
 
+from setuptools import find_packages
+
 try:
     from skbuild import setup
 except ImportError:
@@ -35,5 +37,13 @@ else:
     cmake_args = []
 
 setup(
+    packages=find_packages(
+        include=(
+            "threedigrid_builder",
+            "threedigrid_builder.*",
+        ),
+    ),
     cmake_args=cmake_args,
+    include_package_data=True,
+    zip_safe=False,
 )

--- a/threedigrid_builder/grid/zero_d.py
+++ b/threedigrid_builder/grid/zero_d.py
@@ -300,7 +300,7 @@ class BaseSurfaces:
             centroid_y=centroid_coords[:, 1][self.unique_surfaces_mask],
             dry_weather_flow=self.dry_weather_flow[self.unique_surfaces_mask],
             nr_of_inhabitants=self.nr_of_inhabitants[self.unique_surfaces_mask],
-            **extra_fields
+            **extra_fields,
         )
 
     def as_surface_maps(


### PR DESCRIPTION
This PR migrates the project metadata and most tool configurations to pyproject.toml. The platform-dependent cmake arguments are still in setup.py, and the zest.releaser and flake8 configuration are still in setup.cfg.