### PR TITLE
Limit changed names to database interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedigrid-builder
 1.21.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove internal changes made for previous schema upgrades and limit changes to db interface
 
 
 1.21.0 (2024-11-25)

--- a/threedigrid_builder/grid/boundary_conditions.py
+++ b/threedigrid_builder/grid/boundary_conditions.py
@@ -98,14 +98,14 @@ class BoundaryConditions1D(Array[BoundaryCondition1D]):
 class BoundaryCondition2D:
     id: int
     type: BoundaryType
-    geom: shapely.Geometry
+    the_geom: shapely.Geometry
 
 
 class BoundaryConditions2D(Array[BoundaryCondition2D]):
     def get_intersecting_node_idx(
         self, idx: int, cell_tree: shapely.STRtree
     ) -> np.ndarray:
-        bc_geom = self.geom[idx]
+        bc_geom = self.the_geom[idx]
 
         x1, y1, x2, y2 = shapely.bounds(bc_geom)
         is_horizontal = (x2 - x1) > (y2 - y1)

--- a/threedigrid_builder/grid/zero_d.py
+++ b/threedigrid_builder/grid/zero_d.py
@@ -208,7 +208,7 @@ class BaseSurface:
     code: str
     display_name: str
     area: float
-    geom: shapely.Geometry
+    the_geom: shapely.Geometry
 
     connection_node_id: int
     connection_node_the_geom: shapely.Geometry
@@ -267,7 +267,7 @@ class BaseSurfaces:
         if extra_fields is None:
             extra_fields = {}
 
-        centroids = shapely.centroid(self.geom)
+        centroids = shapely.centroid(self.the_geom)
         no_centroid_mask = shapely.is_missing(centroids)
 
         if np.any(no_centroid_mask):

--- a/threedigrid_builder/interface/db.py
+++ b/threedigrid_builder/interface/db.py
@@ -385,7 +385,7 @@ class SQLite:
         arr["the_geom"] = self.reproject(arr["the_geom"])
         return Surfaces(
             id=np.arange(0, len(arr["surface_id"] + 1), dtype=int),
-            **{name: arr[name] for name in arr.dtype.names}
+            **{name: arr[name] for name in arr.dtype.names},
         )
 
     def get_boundary_conditions_1d(self) -> BoundaryConditions1D:
@@ -411,7 +411,7 @@ class SQLite:
                 session.query(
                     models.BoundaryConditions2D.id,
                     models.BoundaryConditions2D.type,
-                    models.BoundaryConditions2D.geom.label("the_geom")
+                    models.BoundaryConditions2D.geom.label("the_geom"),
                 )
                 .order_by(models.BoundaryConditions2D.id)
                 .as_structarray()
@@ -493,7 +493,6 @@ class SQLite:
         attr_dict = arr_to_attr_dict(
             arr,
             {
-                "geom": "the_geom",
                 "initial_water_level": "initial_waterlevel",
                 "exchange_type": "calculation_type",
                 "exchange_level": "drain_level",
@@ -588,7 +587,6 @@ class SQLite:
                 .as_structarray()
             )
         arr["the_geom"] = self.reproject(arr["the_geom"])
-
 
         # transform to a CrossSectionLocations object
         return CrossSectionLocations(**{name: arr[name] for name in arr.dtype.names})
@@ -719,9 +717,7 @@ class SQLite:
         arr["the_geom"] = self.reproject(arr["the_geom"])
         arr["id"] = np.arange(len(arr["grid_level"]))
 
-        attr_dict = arr_to_attr_dict(
-            arr, {"grid_level": "refinement_level"}
-        )
+        attr_dict = arr_to_attr_dict(arr, {"grid_level": "refinement_level"})
         return GridRefinements(**attr_dict)
 
     def get_dem_average_areas(self) -> DemAverageAreas:

--- a/threedigrid_builder/interface/db.py
+++ b/threedigrid_builder/interface/db.py
@@ -383,10 +383,10 @@ class SQLite:
 
         # reproject
         arr["geom"] = self.reproject(arr["geom"])
-
+        attr_dict = arr_to_attr_dict(arr,{"geom": "the_geom"})
         return Surfaces(
             id=np.arange(0, len(arr["surface_id"] + 1), dtype=int),
-            **{name: arr[name] for name in arr.dtype.names},
+            **attr_dict,
         )
 
     def get_boundary_conditions_1d(self) -> BoundaryConditions1D:
@@ -418,9 +418,10 @@ class SQLite:
                 .as_structarray()
             )
         arr["geom"] = self.reproject(arr["geom"])
+        attr_dict = arr_to_attr_dict(arr,{"geom": "the_geom"})
 
         # transform to a BoundaryConditions1D object
-        return BoundaryConditions2D(**{name: arr[name] for name in arr.dtype.names})
+        return BoundaryConditions2D(**attr_dict)
 
     def get_channels(self) -> Channels:
         """Return Channels"""

--- a/threedigrid_builder/tests/test_boundary_conditions.py
+++ b/threedigrid_builder/tests/test_boundary_conditions.py
@@ -279,7 +279,7 @@ def test_2d_boundary_condition(
     boundary_conditions_2d = BoundaryConditions2D(
         id=range(len(bc_coords)),
         type=[3] * len(bc_coords),
-        geom=shapely.linestrings(bc_coords),
+        the_geom=shapely.linestrings(bc_coords),
     )
 
     nodes, lines = boundary_conditions_2d.get_nodes_and_lines(
@@ -320,7 +320,7 @@ def test_2d_boundary_condition_err(grid2d, bc_coords, expected_message):
     boundary_conditions_2d = BoundaryConditions2D(
         id=range(len(bc_coords)),
         type=[3] * len(bc_coords),
-        geom=shapely.linestrings(bc_coords),
+        the_geom=shapely.linestrings(bc_coords),
     )
 
     with pytest.raises(SchematisationError, match=expected_message):
@@ -384,7 +384,7 @@ def test_2d_boundary_condition_types(grid2d_gw, boundary_type, node_type, kcu, l
     boundary_conditions_2d = BoundaryConditions2D(
         id=[1],
         type=[boundary_type],
-        geom=[shapely.linestrings([(12.0, 3.0), (12.0, 8.0)])],
+        the_geom=[shapely.linestrings([(12.0, 3.0), (12.0, 8.0)])],
     )
     nodes, lines = boundary_conditions_2d.get_nodes_and_lines(
         grid2d_gw.nodes,
@@ -412,7 +412,7 @@ def test_2d_boundary_condition_combined(grid2d_gw):
     boundary_conditions_2d = BoundaryConditions2D(
         id=[1, 2],
         type=[BoundaryType.WATERLEVEL, BoundaryType.GROUNDWATERLEVEL],
-        geom=[shapely.linestrings([(12.0, 3.0), (12.0, 8.0)])] * 2,
+        the_geom=[shapely.linestrings([(12.0, 3.0), (12.0, 8.0)])] * 2,
     )
 
     nodes, lines = boundary_conditions_2d.get_nodes_and_lines(

--- a/threedigrid_builder/tests/test_zero_d.py
+++ b/threedigrid_builder/tests/test_zero_d.py
@@ -57,7 +57,7 @@ def test_surfaces(grid_all):
         # nr_of_inhabitants=[1000.0, 2000.0, 2000.0],
         area=[100.0, 200.0, 200.0],
         # dry_weather_flow=[1.0, 2.0, 2.0],
-        geom=[shapely.points([1.0, 2.0]), None, None],
+        the_geom=[shapely.points([1.0, 2.0]), None, None],
         connection_node_id=[1, 2, 1],
         connection_node_the_geom=[
             shapely.points([1.0, 2.0]),


### PR DESCRIPTION
* Rename `.geom` attributes back to `the_geom` in `grid` module
* Use `label` in query that fetches data from the data instead of complicated `arr_to_attr_dict` remapping
