### PR TITLE
Fix incorrect cross sections for CLOSED_RECTANGLE shapes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedigrid-builder
 1.21.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix creating cross sections with schema 228
 
 
 1.21.2 (2024-12-17)

--- a/threedigrid_builder/grid/cross_section_definitions.py
+++ b/threedigrid_builder/grid/cross_section_definitions.py
@@ -65,7 +65,10 @@ class CrossSectionDefinitions(Array[CrossSectionDefinition]):
                 [getattr(self, attr)[mask] for attr in cross_section_attributes[shape]]
             )
             # Find unique rows and add these to the new_csd_dict with new id's
-            u_arr, u_idx = np.unique(attr_arr, return_index=True)
+            if len(cross_section_attributes[shape]) > 1:
+                u_arr, u_idx = np.unique(attr_arr, axis=0, return_index=True)
+            else:
+                u_arr, u_idx = np.unique(attr_arr, return_index=True)
             new_id = np.arange(len(u_idx)) + len(new_csd_dict["id"])
             for key in new_csd_dict:
                 if key == "id":

--- a/threedigrid_builder/tests/test_cross_section_definitions.py
+++ b/threedigrid_builder/tests/test_cross_section_definitions.py
@@ -515,27 +515,23 @@ def test_tabulate_yz_err(width, height, match):
 class TestCrossSectionDefinitionGetUnique:
     def test_for_closed_rectangle(self):
         csd_in = CrossSectionDefinitions(
-            id=[100, 200],
+            id=[100, 200, 300, 400],
             shape=[
                 constants.CrossSectionShape.CLOSED_RECTANGLE.value,
                 constants.CrossSectionShape.CLOSED_RECTANGLE.value,
+                constants.CrossSectionShape.CLOSED_RECTANGLE.value,
+                constants.CrossSectionShape.CLOSED_RECTANGLE.value,
             ],
-            width=[1, 1],
-            height=[1, 1],
-            cross_section_table=["foo", "bar"],
-            origin_table=["pipe", "weir"],
-            origin_id=[10, 20],
+            width=[1, 3, 1, 3],
+            height=[1, 2, 1, 2],
+            cross_section_table=["foo", "bar", "foo", "bar"],
+            origin_table=["pipe", "weir", "pipe", "pipe"],
+            origin_id=[10, 20, 30, 40],
         )
         unique_definition, _ = csd_in.get_unique()
-        assert unique_definition.id == [
-            0,
-        ]
-        assert unique_definition.width == [
-            1,
-        ]
-        assert unique_definition.height == [
-            1,
-        ]
+        np.testing.assert_array_equal(unique_definition.id, [0, 1])
+        np.testing.assert_array_equal(unique_definition.width, [1, 3])
+        np.testing.assert_array_equal(unique_definition.height, [1, 2])
 
     @pytest.mark.parametrize(
         "shape",
@@ -574,19 +570,19 @@ class TestCrossSectionDefinitionGetUnique:
     )
     def test_for_other_shapes(self, shape):
         csd_in = CrossSectionDefinitions(
-            id=[100, 200],
-            shape=[shape, shape],
-            width=[1, 1],
-            height=[10, 21],
-            cross_section_table=["foo", "foo"],
-            origin_table=["pipe", "weir"],
-            origin_id=[10, 20],
+            id=[100, 200, 300],
+            shape=[shape, shape, shape],
+            width=[1, 1, 100],
+            height=[10, 21, 100],
+            cross_section_table=["foo", "foo", "bar"],
+            origin_table=["pipe", "weir", "weir"],
+            origin_id=[10, 20, 30],
         )
         unique_definition, _ = csd_in.get_unique()
-        assert unique_definition.id == [
-            0,
-        ]
-        assert unique_definition.cross_section_table == ["foo"]
+        np.testing.assert_array_equal(unique_definition.id, [0, 1])
+        np.testing.assert_array_equal(
+            sorted(unique_definition.cross_section_table), sorted(["foo", "bar"])
+        )
 
     def test_mapping(self):
         csd_in = CrossSectionDefinitions(


### PR DESCRIPTION
Fixed bug and extended tests such that this bug would have been caught

Tested fix with gridadmin file created with fix (`gridadmin_fix.h5`):

```
import h5py
import numpy as np

def check_file(h5file):
    f = h5py.File(h5file, 'r')
    print(np.array(f['cross_sections']['tables']))

check_file(Path('gridadmin_227.h5'))
> [[0.  0.8 0.  1.4]
 [0.8 0.  1.4 0. ]]

check_file(Path('gridadmin_228.h5'))
> [[0.  0.8 0.  0.8]
 [0.8 0.  0.8 0. ]]

check_file(Path('gridadmin_fix.h5'))
> [[0.  0.8 0.  1.4]
 [0.8 0.  1.4 0. ]]

```

After the fix the results match those for 227