### PR TITLE
Use geometries from schematisation for pipe, weir and orifice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedigrid-builder
 1.22.1 (unreleased)
 -------------------
 
-- Remove internal changes made for previous schema upgrades and limit changes to db interface
+- Use pipe.geom, weir.geom and orifice.weir to build gridadmin
 
 
 1.22.0 (2025-01-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedigrid-builder
 1.22.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove internal changes made for previous schema upgrades and limit changes to db interface
 
 
 1.22.0 (2025-01-08)

--- a/threedigrid_builder/grid/structures.py
+++ b/threedigrid_builder/grid/structures.py
@@ -75,6 +75,7 @@ class WeirOrifice:  # NL: stuw / doorlaat
     zoom_category: int
     display_name: str
     sewerage: int
+    the_geom: shapely.Geometry
 
 
 class WeirOrifices(Array[WeirOrifice]):

--- a/threedigrid_builder/grid/structures.py
+++ b/threedigrid_builder/grid/structures.py
@@ -115,6 +115,7 @@ class WeirOrifices(Array[WeirOrifice]):
         return Lines(
             id=itertools.islice(line_id_counter, len(self)),
             line=line,
+            line_geometries=self.the_geom,
             content_type=self.content_type,
             content_pk=self.id,
             kcu=self.crest_type,  # implicitly converts CalculationType -> LineType

--- a/threedigrid_builder/interface/db.py
+++ b/threedigrid_builder/interface/db.py
@@ -774,6 +774,7 @@ class SQLite:
             models.Pipe.hydraulic_conductivity_out,
             models.Pipe.hydraulic_conductivity_in,
             models.Pipe.material_id.label("material"),
+            models.Pipe.geom.label("the_geom"),
             case(
                 {
                     models.Pipe.friction_value.isnot(None)
@@ -803,6 +804,7 @@ class SQLite:
         arr["friction_type"][arr["friction_type"] == 4] = 2
         arr["hydraulic_conductivity_out"] /= DAY_IN_SECONDS
         arr["hydraulic_conductivity_in"] /= DAY_IN_SECONDS
+        arr["the_geom"] = self.reproject(arr["the_geom"])
 
         # transform to a Pipes object
         return Pipes(**{name: arr[name] for name in arr.dtype.names})

--- a/threedigrid_builder/interface/db.py
+++ b/threedigrid_builder/interface/db.py
@@ -724,6 +724,7 @@ class SQLite:
             models.Orifice.discharge_coefficient_positive,
             models.Orifice.display_name,
             models.Orifice.sewerage,
+            models.Orifice.geom.label("the_geom"),
             case(
                 {
                     models.Orifice.friction_value.isnot(None)
@@ -754,6 +755,7 @@ class SQLite:
             )
         # map friction_type 4 to friction_type 2 to match crosssectionlocation enum
         arr["friction_type"][arr["friction_type"] == 4] = 2
+        arr["the_geom"] = self.reproject(arr["the_geom"])
 
         return Orifices(**{name: arr[name] for name in arr.dtype.names})
 
@@ -850,6 +852,7 @@ class SQLite:
             models.Weir.discharge_coefficient_positive,
             models.Weir.display_name,
             models.Weir.sewerage,
+            models.Weir.geom.label("the_geom"),
             case(
                 {
                     models.Weir.friction_value.isnot(None)
@@ -876,6 +879,7 @@ class SQLite:
             )
         # map friction_type 4 to friction_type 2 to match crosssectionlocation enum
         arr["friction_type"][arr["friction_type"] == 4] = 2
+        arr["the_geom"] = self.reproject(arr["the_geom"])
 
         return Weirs(**{name: arr[name] for name in arr.dtype.names})
 

--- a/threedigrid_builder/tests/test_db.py
+++ b/threedigrid_builder/tests/test_db.py
@@ -384,6 +384,11 @@ def test_get_weirs(db):
     assert weirs.friction_value[36] == 0.03
     assert weirs.display_name[33] == "KST-JL-76"
     assert weirs.sewerage[0] == 1
+    assert_geometries_equal(
+        weirs.the_geom[0],
+        shapely.from_wkt("LINESTRING (110278.3 517669.1, 110276.3 517669.8)"),
+        tolerance=1,
+    )
 
 
 def test_get_dem_average(db):

--- a/threedigrid_builder/tests/test_db.py
+++ b/threedigrid_builder/tests/test_db.py
@@ -234,6 +234,11 @@ def test_get_pipes(db):
     assert pipes.friction_type[28] == FrictionType.MANNING
     assert pipes.friction_value[36] == 0.0145
     assert pipes.display_name[33] == "71518_71517"
+    assert_geometries_equal(
+        pipes.the_geom[0],
+        shapely.from_wkt("LINESTRING (110267.3 517868.8, 110264.3 517863.5)"),
+        tolerance=1,
+    )
 
 
 def test_get_settings(db):


### PR DESCRIPTION
* Read pipe.geom from schematisation. This sets the `the_geom` of the `Pipe` (`BaseLinear`) object and setting this based on the connection nodes (https://github.com/nens/threedigrid-builder/blob/master/threedigrid_builder/grid/linear.py#L40-L46) will be skipped
* Read weir.geom and orifice.geom from schematisation and add `the_geom` to `WeirOrifice`. Then `the_geom` is used to set `Lines.line_geometries`

Note that modelchecker ensures that geometries of pipes, orifices and weirs do match the connection nodes.