### PR TITLE
Use windows-2019 runner temporarily to fix QGIS crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, windows-2019, macos-14]
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
       - uses: msys2/setup-msys2@v2
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2019'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0


### PR DESCRIPTION
The windows-2019 runner will be unavailable from 30/06/2025, so threedigrid-builder was being compiled on windows-2022. Unfortunately, that causes QGIS segfaults so this commit temporarily reverts that.