### PR TITLE
Include unassigned node check for 1D2D groundwater lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedigrid-builder
 1.24.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Include the check_unassigned for 2D nodes for 1D2D groundwater lines.
 
 
 1.24.3 (2025-04-28)

--- a/threedigrid_builder/grid/grid.py
+++ b/threedigrid_builder/grid/grid.py
@@ -724,7 +724,7 @@ class Grid:
         potential_breaches,
         line_id_counter,
         node_open_water_detection,
-    ) -> Lines1D2D:
+    ):
         """Connect 1D and 2D elements by computing 1D-2D lines.
 
         Every (double) connected node gets a 1D-2D connection to the cell in which it
@@ -798,6 +798,7 @@ class Grid:
         lines_1d2d_gw.assign_groundwater_exchange(self.nodes, cn=connection_nodes)
         lines_1d2d_gw.assign_line_coords(self.nodes)
         lines_1d2d_gw.assign_2d_node(self.cell_tree)
+        lines_1d2d_gw.check_unassigned(self.nodes)
         lines_1d2d_gw.transfer_2d_node_to_groundwater(self.nodes.n_groundwater_cells)
         self.lines += lines_1d2d_gw
 


### PR DESCRIPTION
This will now raise this error for the testmodel in the ticket:

`threedigrid_builder.exceptions.SchematisationError: The following objects are connected but are (partially) outside of the 2D model domain: connection nodes [102078], channels [100233].`