### PR TITLE
Exclude embedded nodes from creating 1D2D groundwater lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedigrid-builder
 1.24.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Exclude embedded nodes from creating 1D2D groundwater lines.
 
 
 1.24.3 (2025-04-28)

--- a/threedigrid_builder/application.py
+++ b/threedigrid_builder/application.py
@@ -209,8 +209,12 @@ def _make_gridadmin(
             node_open_water_detection=grid_settings.node_open_water_detection,
         )
         if grid.meta.has_groundwater:
-            channels.apply_has_groundwater_exchange(grid.nodes, grid.lines)
-            pipes.apply_has_groundwater_exchange(grid.nodes, grid.lines)
+            channels.apply_has_groundwater_exchange(
+                grid.nodes, grid.lines, grid.nodes_embedded
+            )
+            pipes.apply_has_groundwater_exchange(
+                grid.nodes, grid.lines, grid.nodes_embedded
+            )
             grid.add_1d2d_groundwater_lines(line_id_counter, connection_nodes)
 
     if grid_settings.use_0d_inflow in (

--- a/threedigrid_builder/grid/linear.py
+++ b/threedigrid_builder/grid/linear.py
@@ -396,7 +396,9 @@ class BaseLinear:
     def has_groundwater_exchange(self):
         return np.full(len(self), False, dtype=bool)
 
-    def apply_has_groundwater_exchange(self, nodes: Nodes, lines: Lines):
+    def apply_has_groundwater_exchange(
+        self, nodes: Nodes, lines: Lines, embedded_nodes: Nodes
+    ):
         content_pk = self.id[self.has_groundwater_exchange]
 
         if len(content_pk) == 0:
@@ -408,6 +410,10 @@ class BaseLinear:
                 & np.isin(lines.content_pk, content_pk)
             ]
         )
+
+        # Nodes that have been embedded should not transfer groundwater properties to
+        # the nodes they are embedded in
+        node_ids = np.setdiff1d(node_ids, embedded_nodes.embedded_in)
 
         nodes.has_groundwater_exchange[
             np.isin(nodes.id, node_ids)

--- a/threedigrid_builder/tests/test_linear.py
+++ b/threedigrid_builder/tests/test_linear.py
@@ -432,8 +432,9 @@ def test_apply_has_groundwater_exchange(two_linear_objects):
         content_type=LinearObjects.content_type,
         line=[[2, 1], [1, 3], [3, 4]],
     )
+    embedded_nodes = Nodes(id=[])
 
-    two_linear_objects.apply_has_groundwater_exchange(nodes, lines)
+    two_linear_objects.apply_has_groundwater_exchange(nodes, lines, embedded_nodes)
 
     assert_array_equal(nodes.has_groundwater_exchange, [1, 0, 1, 1])
 
@@ -455,7 +456,32 @@ def test_apply_has_groundwater_exchange_boundary_condition(two_linear_objects):
         content_type=LinearObjects.content_type,
         line=[[2, 1], [1, 3], [3, 4]],
     )
+    embedded_nodes = Nodes(id=[])
 
-    two_linear_objects.apply_has_groundwater_exchange(nodes, lines)
+    two_linear_objects.apply_has_groundwater_exchange(nodes, lines, embedded_nodes)
 
     assert_array_equal(nodes.has_groundwater_exchange, [1, 0, 1, 0])
+
+
+@mock.patch.object(LinearObjects, "has_groundwater_exchange", np.array([False, True]))
+def test_apply_has_groundwater_exchange_embedded_nodes(two_linear_objects):
+    nodes = Nodes(
+        id=[1, 2, 3, 4],
+        calculation_type=[
+            CalculationType.CONNECTED,
+            CalculationType.CONNECTED,
+            CalculationType.CONNECTED,
+            CalculationType.BOUNDARY_NODE,
+        ],
+    )
+    lines = Lines(
+        id=range(3),
+        content_pk=[1, 2, 2],
+        content_type=LinearObjects.content_type,
+        line=[[2, 1], [1, 3], [3, 4]],
+    )
+    embedded_nodes = Nodes(id=[1], embedded_in=[3])
+
+    two_linear_objects.apply_has_groundwater_exchange(nodes, lines, embedded_nodes)
+
+    assert_array_equal(nodes.has_groundwater_exchange, [1, 0, 0, 0])


### PR DESCRIPTION
Embedded nodes could create a 1D2D groundwater connection for the 2D node they are embedded in, which is incorrect. This fixes that by excluding them from the `apply_has_groundwater` routine 